### PR TITLE
Add CockroachDB MCP Server to Community Servers list

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ A growing set of community-developed and maintained servers demonstrates various
 - **[ClaudePost](https://github.com/ZilongXue/claude-post)** - ClaudePost enables seamless email management for Gmail, offering secure features like email search, reading, and sending.
 - **[ClickUp](https://github.com/TaazKareem/clickup-mcp-server)** - MCP server for ClickUp task management, supporting task creation, updates, bulk operations, and markdown descriptions.
 - **[Cloudinary](https://github.com/felores/cloudinary-mcp-server)** - Cloudinary Model Context Protocol Server to upload media to Cloudinary and get back the media link and details.
+- **[CockroachDB MCP Server](https://github.com/viragtripathi/cockroachdb-mcp-server)** – Full-featured MCP implementation built with FastAPI and CockroachDB. Supports schema bootstrapping, JSONB storage, LLM-ready CLI, and optional `/debug` endpoints.
 - **[Coda](https://github.com/universal-mcp/coda)** - Coda.io MCP server from **[agentr](https://agentr.dev/)** that provides support for reading and writing data to Coda docs and tables.
 - **[code-assistant](https://github.com/stippi/code-assistant)** - A coding assistant MCP server that allows to explore a code-base and make changes to code. Should be used with trusted repos only (insufficient protection against prompt injections).
 - **[code-executor](https://github.com/bazinga012/mcp_code_executor)** - An MCP server that allows LLMs to execute Python code within a specified Conda environment.


### PR DESCRIPTION
This PR adds a new community-built MCP server implementation using [CockroachDB](https://www.cockroachlabs.com/) to the 🌎 Community Servers section.

### 📦 Project Overview

**Repo:** https://github.com/viragtripathi/cockroachdb-mcp-server  
**Name:** `cockroachdb-mcp-server`

### 🧠 What it is

This is a full-featured Model Context Protocol server built with:

- ✅ [CockroachDB](https://www.cockroachlabs.com/) as the backend (distributed, resilient, JSONB-supporting SQL engine)
- ✅ [FastAPI](https://fastapi.tiangolo.com/) for the server framework
- ✅ Fully spec-aligned CRUD APIs for MCP contexts
- ✅ Optional `/debug` endpoints for safe SELECT queries and metadata access
- ✅ CLI-first development experience via [cockroachdb-mcp-client](https://github.com/viragtripathi/cockroachdb-mcp-client)
- ✅ Supports both self-hosted and CockroachDB Cloud

### 🎯 Why CockroachDB?

CockroachDB offers strong consistency, PostgreSQL compatibility, and horizontal scale — making it an ideal fit for MCP-style persistent context registries.

### 🔖 Notes

- This is a **community-led project** and not (yet) an official integration from the Cockroach Labs product team.
- The project is under active development and intended for production use.